### PR TITLE
list_item config param which is used to control the image preceding e…

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,6 +13,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 	# author = "Bruce Eckel"
 	description = "A Self-Organizing Open-Spaces Unconference"
 
+  list_item = "/images/stf-favicon-32.png"
 	logo = "/images/stf-circle-web.jpg"
 	favicon = "images/stf-favicon-32.png"
 	banner_image = "/images/SummerTechForumBanner.jpg"


### PR DESCRIPTION
list_item config param which is used to control the image preceding every list item within the site.

I've added the new list_item param that is used to control the image that precedes each list item. It's currently set to an image that was already in the images directory, but you can play around with it and see what looks best. 